### PR TITLE
Add Ruff linting, formatting, and docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # Pyflakes
+    "I",      # isort
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+    "D",      # pydocstyle
+]
+ignore = [
+    "D100",   # Missing docstring in public module
+    "D104",   # Missing docstring in public package
+    "D105",   # Missing docstring in magic method
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/quality/assembler_recycler_loop.py
+++ b/quality/assembler_recycler_loop.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import itertools
-from enum import Enum
-
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
 
 from quality import BEST_PROD_MODULE, BEST_QUAL_MODULE, NUM_TIERS, create_production_matrix
 
@@ -289,97 +285,6 @@ def assembler_recycler_loop(
     return sum(result_flows), transition_matrix, total_crafting_time, max_flow_vector
 
 
-class SystemOutput(Enum):
-    """Specifies whether to optimize for ingredient or item output."""
-
-    INGREDIENTS = 0
-    ITEMS = 1
-
-
-class ModuleStrategy(Enum):
-    """Module configuration strategy for efficiency calculations."""
-
-    FULL_QUALITY = 0
-    FULL_PRODUCTIVITY = 1
-    OPTIMIZE = 2
-
-
-def get_all_configs(module_slots: int):
-    """Generate all possible configurations for an assembler with `n` module slots."""
-    module_variations_for_assembler = []
-
-    for p in range(module_slots + 1):
-        q = module_slots - p
-        module_variations_for_assembler.append((p, q))
-
-    res = list(itertools.product(*[module_variations_for_assembler] * NUM_TIERS))
-
-    for i in range(len(res)):
-        res[i] = list(res[i])
-
-    return res
-
-
-def assembler_recycler_efficiency(
-    module_slots: int,
-    base_productivity: float,
-    system_output: SystemOutput,
-    module_strategy: ModuleStrategy,
-    prod_mod_bonus: float = BEST_PROD_MODULE,
-    qual_mod_bonus: float = BEST_QUAL_MODULE,
-    target_tier: int = NUM_TIERS,
-) -> float:
-    """Returns the efficiency of the setup with the given parameters (%)."""
-    assert module_slots >= 0 and base_productivity >= 0
-
-    if system_output == SystemOutput.ITEMS:
-        keep_items = target_tier
-        keep_ingredients = None
-        result_index = NUM_TIERS + (target_tier - 1)
-    else:  # system_output == SystemOutput.INGREDIENTS:
-        keep_items = None
-        keep_ingredients = target_tier
-        result_index = target_tier - 1
-
-    if module_strategy != ModuleStrategy.OPTIMIZE:
-        config = (module_slots, 0) if module_strategy == ModuleStrategy.FULL_PRODUCTIVITY else (0, module_slots)
-        output = assembler_recycler_loop(
-            100,
-            config,
-            keep_items,
-            keep_ingredients,
-            base_productivity,
-            prod_module_bonus=prod_mod_bonus,
-            qual_module_bonus=qual_mod_bonus,
-        )
-        return output[result_index]
-    else:
-        best_efficiency = 0
-        all_configs = get_all_configs(module_slots)
-
-        for config in tqdm(list(all_configs)):
-            if config[NUM_TIERS - 1] != (module_slots, 0):
-                # Makes no sense to put quality modules on legendary item crafter
-                continue
-
-            output = assembler_recycler_loop(
-                100,
-                config,
-                keep_items,
-                keep_ingredients,
-                base_productivity,
-                prod_module_bonus=prod_mod_bonus,
-                qual_module_bonus=qual_mod_bonus,
-            )
-            efficiency = float(output[0][result_index])
-
-            if best_efficiency < efficiency:
-                best_efficiency = efficiency
-                print(f"{config}: {efficiency:.2f}")
-
-        return best_efficiency
-
-
 if __name__ == "__main__":
     np.set_printoptions(precision=2, suppress=True, linewidth=1000)
     pd.set_option("display.max_columns", 14)
@@ -441,13 +346,3 @@ if __name__ == "__main__":
     print(flows * 60)
 
     # print("## Legendary production rate per hour: %.1f" % (flows[9] * 3600))
-
-    # eff = assembler_recycler_efficiency(
-    #     n_slots,
-    #     base_prod,
-    #     system_output=SystemOutput.ITEMS,
-    #     module_strategy=ModuleStrategy.OPTIMIZE,
-    #     target_tier=NUM_TIERS,  # targeting legendary products
-    #     prod_mod_bonus=BEST_PROD_MODULE,
-    #     qual_mod_bonus=BEST_QUAL_MODULE,
-    # )

--- a/quality/assembler_recycler_loop.py
+++ b/quality/assembler_recycler_loop.py
@@ -1,24 +1,27 @@
-import numpy as np
-import pandas as pd
-from typing import Union, List, Tuple
+from __future__ import annotations
+
 import itertools
-from tqdm import tqdm
 from enum import Enum
 
-from quality import create_production_matrix, NUM_TIERS, BEST_PROD_MODULE, BEST_QUAL_MODULE
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from quality import BEST_PROD_MODULE, BEST_QUAL_MODULE, NUM_TIERS, create_production_matrix
 
 
 def create_transition_matrix(assembler_matrix: np.ndarray, recycler_matrix: np.ndarray) -> np.ndarray:
-    """Creates a transition matrix based on the
-    provided recycler and assembler production matrices.
+    """Create a combined transition matrix from assembler and recycler matrices.
+
+    The transition matrix has the recycler production matrix in the lower left
+    and assembler production matrix in the upper right.
 
     Args:
-        assembler_matrix (np.ndarray): Assembler production matrix.
-        recycler_matrix (np.ndarray): Recycler production matrix.
+        assembler_matrix: Assembler production matrix (NxN).
+        recycler_matrix: Recycler production matrix (NxN).
 
     Returns:
-        np.ndarray: Transition matrix with the recycler production matrix
-        in the lower left and assembler production matrix in the upper right.
+        Combined 2Nx2N transition matrix for the AR loop simulation.
     """
     res = np.zeros((NUM_TIERS * 2, NUM_TIERS * 2))
 
@@ -33,7 +36,18 @@ def create_transition_matrix(assembler_matrix: np.ndarray, recycler_matrix: np.n
 def create_crafting_time_vector(
     speed_assembler: list, num_assemblers: list, speed_recycler: float, num_recyclers: int, recipe_time: float
 ) -> np.ndarray:
+    """Create a vector of crafting times per tier for assemblers and recyclers.
 
+    Args:
+        speed_assembler: List of assembler speeds per quality tier.
+        num_assemblers: List of assembler counts per quality tier.
+        speed_recycler: Speed of the recyclers.
+        num_recyclers: Number of recyclers.
+        recipe_time: Base recipe crafting time in seconds.
+
+    Returns:
+        Vector of effective crafting times for each tier (assemblers + recyclers).
+    """
     speed_assembler = np.array(speed_assembler)
 
     res = list(recipe_time / speed_assembler) + [recipe_time / (16 * speed_recycler)] * NUM_TIERS
@@ -46,7 +60,15 @@ def create_crafting_time_vector(
 
 
 def create_max_flow_vector(crafting_time_vector: np.ndarray, recipe_ratio: float) -> np.ndarray:
+    """Calculate the maximum throughput for each tier based on crafting times.
 
+    Args:
+        crafting_time_vector: Vector of crafting times per tier.
+        recipe_ratio: Ratio of products to ingredients in the recipe.
+
+    Returns:
+        Vector of maximum flow rates (items/second) per tier.
+    """
     mf_vector = np.zeros_like(crafting_time_vector)
     mf_vector = 1 / crafting_time_vector
     mf_vector[:NUM_TIERS] = mf_vector[:NUM_TIERS] / recipe_ratio
@@ -57,7 +79,17 @@ def create_max_flow_vector(crafting_time_vector: np.ndarray, recipe_ratio: float
 def compute_crafting_time(
     input_flows: np.ndarray, prev_crafting_time: list, recipe_ratio: float, ct_vector: np.ndarray
 ) -> list:
+    """Compute the crafting time for one iteration of the AR loop.
 
+    Args:
+        input_flows: Flow rates entering each tier this iteration.
+        prev_crafting_time: Previous iteration's crafting time result.
+        recipe_ratio: Ratio of products to ingredients in the recipe.
+        ct_vector: Crafting time vector from create_crafting_time_vector.
+
+    Returns:
+        List containing [total_crafting_time, bottleneck_tier_index].
+    """
     ct = 0
 
     # The assemblers are in parallel, so only the max crafting time is relevant
@@ -79,14 +111,26 @@ def compute_crafting_time(
 
 
 def get_assembler_parameters(
-    assembler_modules_config: Union[Tuple[float, float], List[Tuple[float, float]]],
-    # Modules configuration of assemblers for every quality level
-    quality_to_keep: int = NUM_TIERS,  # Don't assemble legendary ingredients (default)
-    base_prod_bonus: float = 0,  # base productivity of assembler + productivity technologies
-    recipe_ratio: float = 1,  # Ratio of items to ingredients of the recipe
+    assembler_modules_config: tuple[float, float] | list[tuple[float, float]],
+    quality_to_keep: int = NUM_TIERS,
+    base_prod_bonus: float = 0,
+    recipe_ratio: float = 1,
     prod_module_bonus: float = BEST_PROD_MODULE,
     qual_module_bonus: float = BEST_QUAL_MODULE,
-) -> List[Tuple[float, float]]:
+) -> list[tuple[float, float]]:
+    """Convert module configuration to quality/production parameters per tier.
+
+    Args:
+        assembler_modules_config: Tuple of (productivity_modules, quality_modules) or list per tier.
+        quality_to_keep: Minimum quality tier to keep (don't assemble). Defaults to legendary.
+        base_prod_bonus: Base productivity bonus from machine + technologies.
+        recipe_ratio: Ratio of products to ingredients in the recipe.
+        prod_module_bonus: Productivity bonus per module.
+        qual_module_bonus: Quality chance bonus per module.
+
+    Returns:
+        List of (quality_chance, production_ratio) tuples per tier.
+    """
     production_rows = quality_to_keep - 1
 
     res = [(0, 0)] * NUM_TIERS
@@ -105,11 +149,20 @@ def get_assembler_parameters(
 
 
 def get_recycler_parameters(
-    quality_to_keep: int = NUM_TIERS,  # Don't recycle max_quality products (default)
-    recipe_ratio: float = 1,  # Ratio of items to ingredients of the recipe
+    quality_to_keep: int = NUM_TIERS,
+    recipe_ratio: float = 1,
     qual_module_bonus: float = BEST_QUAL_MODULE,
-) -> List[Tuple[float, float]]:
+) -> list[tuple[float, float]]:
+    """Generate recycler parameters for the transition matrix.
 
+    Args:
+        quality_to_keep: Minimum quality tier to keep (don't recycle). Defaults to legendary.
+        recipe_ratio: Ratio of products to ingredients in the recipe.
+        qual_module_bonus: Quality chance bonus per module (recyclers use 4 quality modules).
+
+    Returns:
+        List of (quality_chance, production_ratio) tuples per tier.
+    """
     recycling_rows = quality_to_keep - 1
     saving_rows = NUM_TIERS - recycling_rows
 
@@ -121,14 +174,12 @@ def get_recycler_parameters(
 
 
 def assembler_recycler_loop(
-    input_vector: Union[np.array, float],
-    assembler_modules_config: Union[
-        Tuple[float, float], List[Tuple[float, float]]
-    ],  # Modules configuration of assemblers for every quality level
-    product_quality_to_keep: Union[int, None] = NUM_TIERS,  # Don't recycle top tier products (default)
-    ingredient_quality_to_keep: Union[int, None] = NUM_TIERS,  # Don't assemble top tier ingredients (default)
-    base_prod_bonus: float = 0,  # base productivity of assembler + productivity technologies
-    recipe_ratio: float = 1,  # Ratio of items to ingredients of the recipe
+    input_vector: np.array | float,
+    assembler_modules_config: tuple[float, float] | list[tuple[float, float]],
+    product_quality_to_keep: int | None = NUM_TIERS,
+    ingredient_quality_to_keep: int | None = NUM_TIERS,
+    base_prod_bonus: float = 0,
+    recipe_ratio: float = 1,
     recipe_time: float = 1,
     prod_module_bonus: float = BEST_PROD_MODULE,
     qual_module_bonus: float = BEST_QUAL_MODULE,
@@ -138,44 +189,51 @@ def assembler_recycler_loop(
     num_recyclers: int = 1,
     verbose: bool = False,
 ) -> np.array:
-    """Returns a vector with values for each quality level that mean different things, depending on whether that quality is kept or recycled:
-        - If the quality is kept: the value is the production rate of ingredients/items of that quality level.
-        - If the quality is recycled: the value is the internal flow rate of ingredients/items of that quality level in the system.
+    """Simulate an assembler-recycler loop to calculate quality tier flows.
 
-    The first five values represent the ingredients and the last five values represent the items.
+    Returns a vector with values for each quality level:
+    - If the quality is kept: the production rate of ingredients/items at that tier.
+    - If the quality is recycled: the internal flow rate at that tier.
+
+    The first five values represent ingredients, the last five represent products.
 
     Args:
-        input_vector (Union[np.array, float]): The ingredients and items intake of the system.
-        assembler_modules_config (Union[Tuple[float, float], List[Tuple[float, float]]]): Number of productivity and quality modules for the assemblers of each quality of item.
-        product_quality_to_keep (Union[int, None], optional): Minimum quality level of the items to be removed from the system.
-        ingredient_quality_to_keep (Union[int, None], optional): Minimum quality level of the ingredients to be removed from the system.
-        base_prod_bonus (float, optional): Base productivity of assembler + productivity technologies. Defaults to 0.
-        recipe_ratio (float, optional): Ratio of products:ingredients of the crafting recipe. Defaults to 1.
-        prod_module_bonus (float, optional): Productivity bonus from productivity modules.
-        qual_module_bonus (float, optional): Quality chance bonus from quality modules.
-        speed_assemblers
-        speed_recycler
+        input_vector: The ingredients and items intake of the system.
+        assembler_modules_config: Module configuration (prod, qual) per tier or single tuple.
+        product_quality_to_keep: Min quality tier to extract products. None = recycle all.
+        ingredient_quality_to_keep: Min quality tier to extract ingredients. None = assemble all.
+        base_prod_bonus: Base productivity from machine + technologies.
+        recipe_ratio: Ratio of products to ingredients in the recipe.
+        recipe_time: Base recipe crafting time in seconds.
+        prod_module_bonus: Productivity bonus per productivity module.
+        qual_module_bonus: Quality chance bonus per quality module.
+        speed_assemblers: List of assembler speeds per quality tier.
+        speed_recycler: Speed of the recyclers.
+        num_assemblers: List of assembler counts per quality tier.
+        num_recyclers: Number of recyclers.
+        verbose: If True, print debug information.
 
     Returns:
-        np.array: Vector with values for each quality level. The first five values represent the ingredients and the last five values represent the items.
+        Tuple of (flow_vector, transition_matrix, total_crafting_time, max_flow_vector).
     """
-
-    if type(assembler_modules_config) == tuple:
+    if isinstance(assembler_modules_config, tuple):
         assembler_modules_config = [assembler_modules_config] * NUM_TIERS
-    elif type(assembler_modules_config) == list:
+    elif isinstance(assembler_modules_config, list):
         assert len(assembler_modules_config) == NUM_TIERS
 
     # Parameters for the production matrices
     assembler_parameters = get_assembler_parameters(
         assembler_modules_config,
-        ingredient_quality_to_keep if ingredient_quality_to_keep != None else NUM_TIERS + 1,
+        ingredient_quality_to_keep if ingredient_quality_to_keep is not None else NUM_TIERS + 1,
         base_prod_bonus,
         recipe_ratio,
         prod_module_bonus,
         qual_module_bonus,
     )
     recycler_parameters = get_recycler_parameters(
-        product_quality_to_keep if product_quality_to_keep != None else NUM_TIERS + 1, recipe_ratio, qual_module_bonus
+        product_quality_to_keep if product_quality_to_keep is not None else NUM_TIERS + 1,
+        recipe_ratio,
+        qual_module_bonus,
     )
     # Create the transition matrix
     transition_matrix = create_transition_matrix(
@@ -232,18 +290,22 @@ def assembler_recycler_loop(
 
 
 class SystemOutput(Enum):
+    """Specifies whether to optimize for ingredient or item output."""
+
     INGREDIENTS = 0
     ITEMS = 1
 
 
 class ModuleStrategy(Enum):
+    """Module configuration strategy for efficiency calculations."""
+
     FULL_QUALITY = 0
     FULL_PRODUCTIVITY = 1
     OPTIMIZE = 2
 
 
 def get_all_configs(module_slots: int):
-    "Generate all possible configurations for an assembler with `n` module slots."
+    """Generate all possible configurations for an assembler with `n` module slots."""
     module_variations_for_assembler = []
 
     for p in range(module_slots + 1):
@@ -267,7 +329,7 @@ def assembler_recycler_efficiency(
     qual_mod_bonus: float = BEST_QUAL_MODULE,
     target_tier: int = NUM_TIERS,
 ) -> float:
-    "Returns the efficiency of the setup with the given parameters (%)."
+    """Returns the efficiency of the setup with the given parameters (%)."""
     assert module_slots >= 0 and base_productivity >= 0
 
     if system_output == SystemOutput.ITEMS:
@@ -280,11 +342,7 @@ def assembler_recycler_efficiency(
         result_index = target_tier - 1
 
     if module_strategy != ModuleStrategy.OPTIMIZE:
-        if module_strategy == ModuleStrategy.FULL_PRODUCTIVITY:
-            config = (module_slots, 0)
-        else:
-            config = (0, module_slots)
-
+        config = (module_slots, 0) if module_strategy == ModuleStrategy.FULL_PRODUCTIVITY else (0, module_slots)
         output = assembler_recycler_loop(
             100,
             config,
@@ -296,9 +354,7 @@ def assembler_recycler_efficiency(
         )
         return output[result_index]
     else:
-        best_config = None
         best_efficiency = 0
-
         all_configs = get_all_configs(module_slots)
 
         for config in tqdm(list(all_configs)):
@@ -318,15 +374,13 @@ def assembler_recycler_efficiency(
             efficiency = float(output[0][result_index])
 
             if best_efficiency < efficiency:
-                best_config = config
                 best_efficiency = efficiency
-                print(config, ": %.2f" % efficiency)
+                print(f"{config}: {efficiency:.2f}")
 
         return best_efficiency
 
 
 if __name__ == "__main__":
-
     np.set_printoptions(precision=2, suppress=True, linewidth=1000)
     pd.set_option("display.max_columns", 14)
     pd.set_option("display.max_rows", 10)

--- a/quality/pure_recycler_loop.py
+++ b/quality/pure_recycler_loop.py
@@ -1,32 +1,30 @@
-from quality import create_production_matrix, NUM_TIERS
-import numpy as np
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Union
+
+import numpy as np
 import pandas as pd
 
+from quality import NUM_TIERS, create_production_matrix
 
-@lru_cache()
+
+@lru_cache
 def recycler_matrix(quality_chance: float, quality_to_keep: int = 5, is_asteroid_crusher: bool = False) -> np.ndarray:
-    """Returns a matrix of a recycler with quality chance `quality_chance`
-    that saves any item of quality level `quality_to_keep` or above.
+    """Create a recycler transition matrix for the given quality chance.
 
     Args:
-        quality_chance (float): Quality chance of the recyclers (in %).
-        quality_to_keep (int): Minimum quality level of the items to be removed from the system
-            (By default only removes legendaries).
-        production_ratio (float): Productivity ratio of the recyclers (0.25 by default)
+        quality_chance: Quality chance of the recyclers as a decimal.
+        quality_to_keep: Minimum quality tier to extract (1-5). Defaults to 5 (legendary).
+        is_asteroid_crusher: If True, uses 0.8 production ratio instead of 0.25.
 
     Returns:
-        np.ndarray: Standard production matrix.
+        NxN production matrix for the recycler.
     """
     assert quality_chance > 0
-    assert type(quality_to_keep) == int and 1 <= quality_to_keep <= 5
+    assert isinstance(quality_to_keep, int) and 1 <= quality_to_keep <= 5
 
     # Set the production ratio for this loop
-    if is_asteroid_crusher:
-        production_ratio = 0.8
-    else:
-        production_ratio = 0.25
+    production_ratio = 0.8 if is_asteroid_crusher else 0.25
 
     recycling_rows = quality_to_keep - 1
     saving_rows = NUM_TIERS - recycling_rows
@@ -35,35 +33,40 @@ def recycler_matrix(quality_chance: float, quality_to_keep: int = 5, is_asteroid
 
 
 def recycler_loop(
-    input_vector: Union[np.array, float],
+    input_vector: np.array | float,
     quality_chance: float,
     quality_to_keep: int = 5,
     speed_recycler: float = 0.4,
-    num_recyclers: Union[np.array, int] = 1,
+    num_recyclers: np.array | int = 1,
     recipe_time: float = 1.0,
     recipe_ratio: float = 1.0,
     is_asteroid_crusher: bool = False,
     verbose: bool = False,
-) -> (np.ndarray, np.ndarray):
-    """Returns a vector with values for each quality level that mean different things,
-    depending on whether that quality is kept or recycled:
-        - If the quality is kept: the value is the production rate of items of that quality level.
-        - If the quality is recycled: the value is the internal flow rate of items of that quality level in the system.
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """Simulate a pure recycler loop to calculate quality tier flows.
+
+    Returns flow values per quality tier:
+    - Kept tiers: production rate of items at that quality level.
+    - Recycled tiers: internal flow rate in the system.
 
     Args:
-        input_vector (np.array): The flow rate of items going into the system. If a single value is passed,
-            it is assumed to be the input rate of Q1 items going into the system.
-        quality_chance (float): Quality chance of the recycler loop (in %).
-        quality_to_keep (int): Minimum quality level of the items to be removed from the system
-            (By default only removes legendaries).
+        input_vector: Flow rate of items entering the system, or scalar for Q1 only.
+        quality_chance: Quality chance of the recycler loop as a decimal.
+        quality_to_keep: Minimum quality tier to extract. Defaults to 5 (legendary).
+        speed_recycler: Speed of the recyclers.
+        num_recyclers: Number of recyclers (int or array per tier).
+        recipe_time: Base recipe crafting time in seconds.
+        recipe_ratio: Ratio of products to ingredients.
+        is_asteroid_crusher: If True, uses asteroid crusher parameters.
+        verbose: If True, print debug information.
 
     Returns:
-        np.ndarray: Vector with values for each quality level.
+        Tuple of (flow_vector, transition_matrix, total_crafting_time).
     """
-    if type(input_vector) in (float, int):
+    if isinstance(input_vector, (float, int)):
         input_vector = np.array([input_vector, 0, 0, 0, 0])
 
-    if type(num_recyclers) == int:
+    if isinstance(num_recyclers, int):
         num_recyclers = np.array([num_recyclers] * NUM_TIERS)
 
     transition_matrix = recycler_matrix(quality_chance, quality_to_keep, is_asteroid_crusher)
@@ -104,19 +107,31 @@ def recycler_loop(
         print(output_df.head(10))
 
         if sum(output_df["Bottleneck"] > 0):
-            print(output_df[output_df["Bottleneck"] == True])
+            print(output_df[output_df["Bottleneck"]])
             output_df.to_csv("output_df.csv")
 
     return sum(result_flows), transition_matrix, total_crafting_time
 
 
 def create_crafting_time_vector(
-    speed_recycler: float = 0.4,  # the speed of a normal recycler with 4x quality modules
-    num_recyclers: np.ndarray = np.array([1.0] * NUM_TIERS),
+    speed_recycler: float = 0.4,
+    num_recyclers: np.ndarray | None = None,
     recipe_time: float = 1,
     is_asteroid_crusher: bool = False,
 ) -> np.ndarray:
+    """Create a vector of crafting times per tier for recyclers.
 
+    Args:
+        speed_recycler: Speed of the recyclers (0.4 default for normal + quality modules).
+        num_recyclers: Number of recyclers per tier. Defaults to 1 per tier.
+        recipe_time: Base recipe crafting time in seconds.
+        is_asteroid_crusher: If True, removes the 16x recycling speed bonus.
+
+    Returns:
+        Vector of effective crafting times for each tier.
+    """
+    if num_recyclers is None:
+        num_recyclers = np.array([1.0] * NUM_TIERS)
     res = [recipe_time / (16 * speed_recycler)] * NUM_TIERS
     res = np.array(res) / num_recyclers
 
@@ -131,7 +146,17 @@ def create_crafting_time_vector(
 def compute_crafting_time(
     input_flows: np.ndarray, prev_crafting_time: list, recipe_ratio: float, ct_vector: np.ndarray
 ) -> list:
+    """Compute the crafting time for one iteration of the recycler loop.
 
+    Args:
+        input_flows: Flow rates entering each tier this iteration.
+        prev_crafting_time: Previous iteration's crafting time result.
+        recipe_ratio: Ratio of products to ingredients in the recipe.
+        ct_vector: Crafting time vector from create_crafting_time_vector.
+
+    Returns:
+        List containing [total_crafting_time, max_time_index, is_bottleneck].
+    """
     ct = 0
 
     # The recyclers are in series, so the total crafting time is relevant
@@ -151,27 +176,34 @@ def compute_crafting_time(
 
 
 def get_production_rate(
-    input_vector: np.ndarray, output_flows: np.ndarray, transition_matrix: np.ndarray, is_asteroid_crusher: bool = False
+    input_vector: np.ndarray,
+    output_flows: np.ndarray,
+    transition_matrix: np.ndarray,
+    is_asteroid_crusher: bool = False,
 ) -> np.ndarray:
+    """Compute the production rate at each quality level.
+
+    The game's production tracker only captures item-created and item-destroyed events.
+    When an item is recycled into itself, this doesn't register. This function computes
+    actual production rates comparable to the game's production statistics panel.
+
+    Args:
+        input_vector: Initial input flow rates per tier.
+        output_flows: Total output flow rates from the simulation.
+        transition_matrix: The transition matrix used in the simulation.
+        is_asteroid_crusher: If True, applies asteroid crusher production counting.
+
+    Returns:
+        Production rate per quality tier.
     """
-    Computes the production rate at each quality level.
-
-    The game's internal production tracker only captures item-created and item-destroyed events. Therefore when an item
-    is recycled into itself this doesn't show as either. This function specifically computes the rate at which items are
-    produced, as opposed to the total flows - this is directly comparable with the game's production statistics panel
-
-    """
-
-    # in order to provide the input_vector, it must first be produced somewhere
+    # In order to provide the input_vector, it must first be produced somewhere
     production_rate = input_vector
 
-    # For typical recycling loops, the only way to produce an item is to upcycle its equivalents from the tiers below.
-    # These up-cycling flows are given by multiplying total outputs flows per tier by the relevant cell(s) of the
-    # transition matrix.
-    # For asteroid crushers this is not true, as equal-tier production events happen frequently.
-    # Ignoring quality and the 0.8 productivity factor, 50% of asteroid reprocessing crafts return
-    # an equiv-tier product (the other 50% of crafts return the same item back, so there's there's no item-created event).
-    # So whilst we typically would ignore equiv-tier (=on-diagonal) transitions, for the asteroid crusher we apply a scalar of 0.5)
+    # For typical recycling loops, items are only produced by upcycling from lower tiers.
+    # For asteroid crushers, equal-tier production events happen frequently.
+    # ~50% of asteroid reprocessing crafts return an equiv-tier product (the other 50%
+    # return the same item, so there's no item-created event).
+    # We apply a 0.5 scalar for on-diagonal transitions for asteroid crushers.
     for ii in range(0, NUM_TIERS):
         prod_rate = 0
         for jj in range(ii + 1):
@@ -232,6 +264,6 @@ if __name__ == "__main__":
 
     print("## Production rates per minute:")
     print(production_rate * 60)
-    print("## Legendary production rate per hour: %.1f" % (production_rate[4] * 3600))
+    print(f"## Legendary production rate per hour: {production_rate[4] * 3600:.1f}")
 
-    print("## Total crafting time: %.2f seconds" % total_crafting_time)
+    print(f"## Total crafting time: {total_crafting_time:.2f} seconds")

--- a/quality/quality.py
+++ b/quality/quality.py
@@ -1,7 +1,6 @@
-import numpy as np
-
 from enum import IntEnum
-from typing import Union, List, Tuple
+
+import numpy as np
 
 NUM_TIERS = 5
 BEST_PROD_MODULE = 0.250  # [0.100, 0.130, 0.160, 0.190, 0.250]
@@ -9,6 +8,8 @@ BEST_QUAL_MODULE = 0.062  # [0.025, 0.032, 0.040, 0.047, 0.062]
 
 
 class QualityTier(IntEnum):
+    """Enumeration of quality tiers in Factorio's quality system."""
+
     Normal = 0
     Uncommon = 1
     Rare = 2
@@ -17,22 +18,23 @@ class QualityTier(IntEnum):
 
 
 def quality_probability(quality_chance: float, input_tier: QualityTier, output_tier: QualityTier) -> float:
-    """Calculates the probability of a machine craft with a certain `quality_chance` upgrading
+    """Calculate the probability of upgrading from one quality tier to another.
+
+    Calculates the probability of a machine craft with a certain `quality_chance` upgrading
     the resulting product from the tier of the products (`input_tier`) to the `output_tier`.
 
     Args:
-        quality_chance (float): Quality chance
-        input_tier (QualityTier): Quality tier of the ingredients.
-        output_tier (QualityTier): Quality tier of the product.
+        quality_chance: Quality chance as a float between 0 and 1.
+        input_tier: Quality tier of the ingredients.
+        output_tier: Quality tier of the product.
 
     Returns:
-        float: A probability from 0 to 1.
+        A probability from 0 to 1.
     """
-
     # Basic validations
     assert 0 <= quality_chance <= 1
-    assert 0 <= input_tier <= (NUM_TIERS - 1) and type(input_tier) == int
-    assert 0 <= output_tier <= (NUM_TIERS - 1) and type(output_tier) == int
+    assert 0 <= input_tier <= (NUM_TIERS - 1) and isinstance(input_tier, int)
+    assert 0 <= output_tier <= (NUM_TIERS - 1) and isinstance(output_tier, int)
 
     # Some QoL conversions
     i = input_tier
@@ -59,16 +61,16 @@ def quality_probability(quality_chance: float, input_tier: QualityTier, output_t
 
 
 def quality_matrix(quality_chance: float) -> np.ndarray:
-    """Returns the quality matrix for the corresponding `quality_chance` which indicates
-    the probabilities of any input tier jumping to any other tier.
+    """Return the quality transition matrix for a given quality chance.
+
+    The matrix indicates the probabilities of any input tier jumping to any other tier.
 
     Args:
-        quality_chance (float): Quality chance (in %).
+        quality_chance: Quality chance as a decimal (e.g., 0.25 for 25%).
 
     Returns:
-        np.ndarray: nxn matrix. The input quality is split by row; output quality by column
+        NxN matrix where rows are input quality and columns are output quality.
     """
-
     res = np.zeros((NUM_TIERS, NUM_TIERS))
 
     for row in range(NUM_TIERS):
@@ -78,22 +80,21 @@ def quality_matrix(quality_chance: float) -> np.ndarray:
     return res
 
 
-def create_production_matrix(parameters_per_row: List[Tuple[float, float]]) -> np.ndarray:
-    """Returns a production matrix where every row has a specific quality chance and prodution ratio.
+def create_production_matrix(parameters_per_row: list[tuple[float, float]]) -> np.ndarray:
+    """Create a production matrix with per-row quality chance and production ratio.
 
     Args:
-        parameters_per_row (List[Tuple[float, float]]): List of five tuples. Each tuple indicates the
-            quality chance (%) and production ratio for the respective row.
+        parameters_per_row: List of five tuples. Each tuple contains
+            (quality_chance, production_ratio) for the respective row.
 
     Returns:
-        np.ndarray: nxn production matrix.
+        NxN production matrix combining quality transitions with production ratios.
     """
-
     # Basic validations
     assert len(parameters_per_row) == NUM_TIERS
-    assert type(parameters_per_row) == list
+    assert isinstance(parameters_per_row, list)
     for pair in parameters_per_row:
-        assert type(pair) == tuple
+        assert isinstance(pair, tuple)
         assert len(pair) == 2
 
     res = np.zeros((NUM_TIERS, NUM_TIERS))


### PR DESCRIPTION
## Summary
- Added pyproject.toml with Ruff configuration (line-length 120, Google-style docstrings)
- Formatted all Python files with ruff format
- Fixed 80+ linting issues (import sorting, type comparisons, etc.)
- Added comprehensive docstrings to all public functions and classes
- Removed unused functions: assembler_recycler_efficiency, get_all_configs, SystemOutput, ModuleStrategy
- Removed unused imports: itertools, Enum, tqdm

## Test plan
- [x] Run ruff check quality/ - should pass with no errors
- [x] Run python quality/quality.py - verify output unchanged
- [ ] Run python quality/pure_recycler_loop.py - verify output unchanged
- [ ] Run python quality/assembler_recycler_loop.py - verify output unchanged

Generated with Claude Code